### PR TITLE
Fix parsing of source and dest keys in VCAP_SERVICES

### DIFF
--- a/mariadb/migrate.sh
+++ b/mariadb/migrate.sh
@@ -2,9 +2,9 @@
 
 set -e -o pipefail
 
-# Needs to be verified that the ranges are correct...
-source=$(echo $VCAP_SERVICES | jq -r '."mariadb-k8s-database"[] | select(.credentials.host | (contains("10.250") or contains("10.144") ))')
-dest=$(echo $VCAP_SERVICES | jq -r '."mariadb-k8s-database"[] | select(.credentials.host | contains("10.197"))')
+# Parse source and destination from VCAP_SERVICES
+source=$(echo $VCAP_SERVICES | jq -r '."mariadb-k8s-database"[]')
+dest=$(echo $VCAP_SERVICES | jq -r '."mariadb-database"[]? // ."mariadb-database-premium"[]?')
 
 # Source
 SRC_HOST=$(echo $source | jq -r '.credentials.host')

--- a/redis/migrate.sh
+++ b/redis/migrate.sh
@@ -3,8 +3,8 @@
 set -e -o pipefail
 
 # Parse source and destination from VCAP_SERVICES
-source=$(echo $VCAP_SERVICES | jq -r '."redis-k8s"[] | select(.credentials.host | (contains("10.250") or contains("10.144") ))')
-dest=$(echo $VCAP_SERVICES | jq -r '."redis-k8s"[] | select(.credentials.host | contains("10.197"))')
+source=$(echo $VCAP_SERVICES | jq -r '."redis-k8s"[]')
+dest=$(echo $VCAP_SERVICES | jq -r '."redis"[]? // ."redis-premium"[]?')
 
 # Source Redis configuration
 SRC_HOST=$(echo $source | jq -r '.credentials.host')


### PR DESCRIPTION
The services have been renamed on the new infra, due to this we don't need to filter by IP address anymore but can filter by service name